### PR TITLE
fixing wordlist

### DIFF
--- a/core/BRBIP39WordsEn.h
+++ b/core/BRBIP39WordsEn.h
@@ -1821,7 +1821,7 @@ static const char *BIP39WordsEn[BIP39_WORDLIST_COUNT] = {
     "tent",
     "term",
     "test",
-    "address",
+    "text",
     "thank",
     "that",
     "theme",


### PR DESCRIPTION
We found that the wordlist in this is incorrect. The word Address is in it twice, the second one should be Text. Tron is putting together an article to help those that run into this issue.